### PR TITLE
[WGO-29] remove raise exc when it fails to send event on save to outbox

### DIFF
--- a/jaiminho/send.py
+++ b/jaiminho/send.py
@@ -46,7 +46,10 @@ def save_to_outbox(func):
                 options=options,
             )
             event_failed_to_publish.send(sender=func, event_payload=payload)
-            raise
+            if settings.raise_on_publishing_error:
+                raise
+            return
+
         return result
 
     inner.original_func = func

--- a/jaiminho/settings.py
+++ b/jaiminho/settings.py
@@ -11,6 +11,8 @@ except AttributeError:
 persist_all_events = jaiminho_settings.get("PERSIST_ALL_EVENTS", False)
 default_encoder = jaiminho_settings.get("DEFAULT_ENCODER", DjangoJSONEncoder)
 time_to_delete = jaiminho_settings.get("TIME_TO_DELETE", timedelta(days=7))
+raise_on_publishing_error = jaiminho_settings.get("RAISE_ON_PUBLISHING_ERROR", True)
+
 default_capture_exception = jaiminho_settings.get(
     "DEFAULT_CAPTURE_EXCEPTION", sentry_sdk.capture_exception
 )


### PR DESCRIPTION
remove raise exc when it fails to send event on save to outbox, for more details, check discussions's thread https://loadsmart.slack.com/archives/C03G0RQG0RG/p1657200367976739

JIRA task: https://loadsmart.atlassian.net/browse/WGO-29