### PR TITLE
[WGO-104] - Fix relay_events command to use the command pattern

### DIFF
--- a/jaiminho/management/commands/events_relay.py
+++ b/jaiminho/management/commands/events_relay.py
@@ -16,14 +16,8 @@ class Command(BaseCommand):
             "--run-in-loop",
             action="store_true",
             help="Define if command should run in loop or just once",
+            default=False
         )
-        parser.add_argument(
-            "--no-run-in-loop",
-            dest="run_in_loop",
-            action="store_false",
-            help="Define if command should run in loop or just once",
-        )
-        parser.set_defaults(run_in_loop=False)
 
         parser.add_argument(
             "--loop-interval",

--- a/jaiminho_django_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_project/tests/management/commands/test_validate_relay_events.py
@@ -220,7 +220,7 @@ class TestValidateEventsRelay:
 
         assert event_relayer_mock.relay.call_count == 3
 
-    def test_accept_no_run_in_loop_as_argument(
+    def test_does_not_run_in_loop_by_default(
         self,
         mock_log_metric,
         mocker,
@@ -230,7 +230,7 @@ class TestValidateEventsRelay:
 
         command = validate_events_relay.Command()
         command.event_relayer = event_relayer_mock
-        call_command(command, "--no-run-in-loop")
+        call_command(command)
 
         assert event_relayer_mock.relay.call_count == 1
 


### PR DESCRIPTION
With these changes we can use only the desired commands like

`python manage.py events_relay --stream crm-interactions-action` instead of passing all the arguments

now we can enable `run_in_loop` by using `--run-in-loop` to run the command only once we don't need to pass any extra param, but now the param is optional

![image](https://user-images.githubusercontent.com/18268454/200953933-e4653247-ec06-49f9-a1b5-e43c5e2623f6.png)

![image](https://user-images.githubusercontent.com/18268454/200954025-7b28007c-41cd-47b9-afea-5fd0938356dc.png)
