### PR TITLE
feat: Switch release from Gemfury to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,5 @@ dist: clean
 	python setup.py bdist_wheel --universal
 
 release: dist
-	curl --show-error --fail -F package=@`find dist -name "jaiminho-*.whl"` $(PRIVATE_PYPI_UPLOAD_URL)
+	pip install twine
+	python -m twine upload --non-interactive --username __token__ --password ${PYPI_TOKEN} dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ exclude_lines =
 
 [xml]
 output = build/coverage.xml
+
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ version = os.getenv("CIRCLE_TAG", os.getenv("CIRCLE_SHA1")) or "0.0.0"
 
 
 setup(
-    name="jaiminho",
+    name="django-jaiminho",
     version=version,
     description="Python library generated using cookiecutter template",
     long_description=long_description,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Switch release from Gemfury to PyPI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We should release `django-jaiminho` through PyPi to be available to the whole community instead of internal private repository.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
Validated through the pipeline.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Releases are available for internal usage only.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Releases will be available at PyPI instead.
