### PR TITLE
add service maturity level attributes to catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     github.com/project-slug: loadsmart/django-jaiminho
     circleci.com/project-slug: github/loadsmart/django-jaiminho
+    opslevel.com/tier: tier_4
   tags:
     - python
 spec:


### PR DESCRIPTION
### Context
The purpose of this pull request is to ensure the repository has basic attributes for service maturity level in backstage catalog, in line with the service maturity level initiative led by the Developer Productivity Squad.
