### PR TITLE
Use iterator in event cleaner

### DIFF
--- a/jaiminho/management/commands/event_cleaner.py
+++ b/jaiminho/management/commands/event_cleaner.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 def chunked_iterator(queryset, chunk_size=500):
     paginator = Paginator(queryset, chunk_size)
     for page in range(1, paginator.num_pages + 1):
-        yield paginator.page(page)
+        for item in paginator.page(page).object_list:
+            yield item
 
 
 class Command(BaseCommand):
@@ -33,8 +34,8 @@ class Command(BaseCommand):
             "JAIMINHO-EVENT-CLEANER: Start cleaning up events .."
         )
 
-        for events in chunked_iterator(events_to_delete):
-            events.delete()
+        for event in chunked_iterator(events_to_delete):
+            event.delete()
 
         logger.info(
             "JAIMINHO-EVENT-CLEANER: Successfully deleted %s events",

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_event_cleaner.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_event_cleaner.py
@@ -69,9 +69,6 @@ class TestEventCleanerCommand:
         assert len(Event.objects.all()) == 4
         call_command(validate_event_cleaner.Command())
         assert len(Event.objects.all()) == 4
-        assert (
-            "JAIMINHO-EVENT-CLEANER: Did not found events to be deleted" in caplog.text
-        )
 
     def test_command_without_time_to_delete_configuration_uses_default_7_days(
         self,


### PR DESCRIPTION
## Description
Use Django paginator  to reduce memory footprint of event cleaner

## Motivation and Context
We detected the clean-up is being killed due to memory usage in some cases.

## How has this been tested?
Unit tests already cover this.

