### PR TITLE
readme: add circleci and coveralls badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jaiminho
 
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/loadsmart/django-jaiminho/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/loadsmart/django-jaiminho/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/loadsmart/django-jaiminho/badge.svg?branch=master)](https://coveralls.io/github/loadsmart/django-jaiminho?branch=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
 A broker agnostic implementation of the outbox and other message resilience patterns for Django apps. 


### PR DESCRIPTION
## Description
Adds:
[![CircleCI](https://dl.circleci.com/status-badge/img/gh/loadsmart/django-jaiminho/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/loadsmart/django-jaiminho/tree/master)
[![Coverage Status](https://coveralls.io/repos/github/loadsmart/django-jaiminho/badge.svg?branch=master)](https://coveralls.io/github/loadsmart/django-jaiminho?branch=master)
... to `README.md`

## Motivation and Context
To inform others of where build is done and what's the test coverage of the library

## How has this been tested?
Previewing Markdown file on GitHub
