### PR TITLE
feat: Update event_cleaner to consume less memory

### DIFF
--- a/jaiminho/management/commands/event_cleaner.py
+++ b/jaiminho/management/commands/event_cleaner.py
@@ -1,21 +1,13 @@
 import logging
-
 from datetime import timedelta
+
 from django.core.management import BaseCommand
 from django.utils import timezone
-from django.core.paginator import Paginator
 
 from jaiminho import settings
 from jaiminho.models import Event
 
 logger = logging.getLogger(__name__)
-
-
-def chunked_iterator(queryset, chunk_size=500):
-    paginator = Paginator(queryset, chunk_size)
-    for page in range(1, paginator.num_pages + 1):
-        for item in paginator.page(page).object_list:
-            yield item
 
 
 class Command(BaseCommand):
@@ -30,14 +22,11 @@ class Command(BaseCommand):
             sent_at__lt=deletion_threshold_timestamp
         )
 
-        logger.info(
-            "JAIMINHO-EVENT-CLEANER: Start cleaning up events .."
-        )
+        logger.info("JAIMINHO-EVENT-CLEANER: Start cleaning up events ..")
 
-        for event in chunked_iterator(events_to_delete):
-            event.delete()
+        count = events_to_delete._raw_delete(events_to_delete.db)
 
         logger.info(
             "JAIMINHO-EVENT-CLEANER: Successfully deleted %s events",
-            len(events_to_delete),
+            count,
         )

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_event_cleaner.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_event_cleaner.py
@@ -1,12 +1,13 @@
-import pytest
-
 from datetime import timedelta
+
+import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
 from jaiminho.models import Event
 from jaiminho.tests.factories import EventFactory
-from jaiminho_django_test_project.management.commands import validate_event_cleaner
+from jaiminho_django_test_project.management.commands import \
+    validate_event_cleaner
 
 pytestmark = pytest.mark.django_db
 
@@ -81,7 +82,5 @@ class TestEventCleanerCommand:
         call_command(validate_event_cleaner.Command())
 
         remaining_events = Event.objects.all()
-        assert set(remaining_events) == set(
-            [*older_events, *newer_events, *not_sent_events]
-        )
+        assert set(remaining_events) == {*older_events, *newer_events, *not_sent_events}
         assert len(Event.objects.all()) == 6


### PR DESCRIPTION
## Description
Change the command `event_cleaner` to use the `_raw_delete` method.

## Motivation and Context
Calling the `delete` manager method on a queryset result is not efficient as it checks relations, generates some signals, and does some validations.

This method `_raw_delete` is not in the documentation, but it basically runs a raw delete without the validations. We can use it here as the model `Event` doesn't have any relations.

About `_raw_delete`: https://til.simonwillison.net/django/efficient-bulk-deletions-in-django

## How has this been tested?
Deployed in a test environment with 100k events:

**Current:**
- Took ~9min to run
- Did not delete all

**New:**
- Took ~1min to run
- Delete everything

## What is the current behavior?
Using Django ORM `delete()`, which performs poorly for bulk delete.

## What is the new behavior?
About `_raw_delete()` instead.

![Screenshot 2023-07-18 at 11 09 02](https://github.com/loadsmart/django-jaiminho/assets/2227228/89c95bb6-7337-4016-bfd8-9e5e14174037)


