### PR TITLE
chore: Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,40 @@ You can use Jaiminho's [EventCleanerCommand](https://github.com/loadsmart/django
 
 The default time interval is `7 days`. You can use the `TIME_TO_DELETE` setting to change it. It should be added to `JAIMINHO_CONFIG` and must be a valid [timedelta](https://docs.python.org/3/library/datetime.html#timedelta-objects).
 
+### Running as cron jobs
+
+You can run those commands in a cron job. Here are some config examples:
+
+```yaml
+  - name: relay-failed-outbox-events
+    schedule: "*/15 * * * *"
+    suspend: false
+    args:
+      - ddtrace-run
+      - python
+      - manage.py
+      - events_relay
+    resources:
+      requests:
+        cpu: 1
+      limits:
+        memory: 384Mi
+
+  - name: delete-old-outbox-events
+    schedule: "0 5 * * *"
+    suspend: false
+    args:
+      - ddtrace-run
+      - python
+      - manage.py
+      - event_cleaner
+    resources:
+      requests:
+        cpu: 1
+      limits:
+        memory: 384Mi
+```
+
 ### Relay per stream and Overwrite publish strategy
 
 Different streams can have different requirements. You can save separate events per streams by using the `@save_to_outbox_stream` decorator:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # For package requirements, please see setup.py
 
 pytest==8.3.3
-pytest-cov==6.0.0
+pytest-cov==5.0.0
 pytest-django==4.9.0
 pytest-mock~=3.14.0
 tox==4.23.2


### PR DESCRIPTION
## Description

- Improving docs by adding examples of using Django commands as cron jobs
- Downgrading `pytest-cov==5.0.0` to be compatible with Python 3.8

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Same

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
NA

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
NA

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
NA
