### PR TITLE
fix: pin twine version to fix release failure and avoid RCE exploit by handling BadSignature errors properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,5 @@ dist: clean
 	python setup.py bdist_wheel --universal
 
 release: dist
-	pip install twine
+	pip install twine==6.0.1
 	python -m twine upload --non-interactive --username __token__ --password ${PYPI_TOKEN} dist/*

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -1,6 +1,7 @@
 import logging
 import dill
 
+from django.core.signing import BadSignature
 
 from jaiminho.constants import PublishStrategyType
 from jaiminho.models import Event
@@ -24,6 +25,12 @@ def _extract_original_func(event):
     fn = dill.loads(event.function)
     original_fn = getattr(fn, "original_func", fn)
     return original_fn
+
+
+def warn_stuck_on_error(event):
+    logger.warning(
+        f"JAIMINHO-EVENTS-RELAY: Events relaying are stuck due to failing Event: {event}"
+    )
 
 
 class EventRelayer:
@@ -66,6 +73,15 @@ class EventRelayer:
                 event_published_by_events_relay.send(
                     sender=original_fn, event_payload=event_payload, args=args, **kwargs
                 )
+            except BadSignature as exception:
+                logger.warning(
+                    f"JAIMINHO-EVENTS-RELAY: Event has been tampered, Event: {event}"
+                )
+                _capture_exception(exception)
+
+                if self.__stuck_on_error(event):
+                    warn_stuck_on_error(event)
+                    return
 
             except (ModuleNotFoundError, AttributeError) as e:
                 logger.warning(
@@ -74,9 +90,7 @@ class EventRelayer:
                 _capture_exception(e)
 
                 if self.__stuck_on_error(event):
-                    logger.warning(
-                        f"JAIMINHO-EVENTS-RELAY: Events relaying are stuck due to failing Event: {event}"
-                    )
+                    warn_stuck_on_error(event)
                     return
 
             except BaseException as e:
@@ -90,9 +104,7 @@ class EventRelayer:
                 _capture_exception(e)
 
                 if self.__stuck_on_error(event):
-                    logger.warning(
-                        f"JAIMINHO-EVENTS-RELAY: Events relaying are stuck due to failing Event: {event}"
-                    )
+                    warn_stuck_on_error(event)
                     return
 
     def __stuck_on_error(self, event):

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -27,12 +27,6 @@ def _extract_original_func(event):
     return original_fn
 
 
-def warn_stuck_on_error(event):
-    logger.warning(
-        f"JAIMINHO-EVENTS-RELAY: Events relaying are stuck due to failing Event: {event}"
-    )
-
-
 class EventRelayer:
     def relay(self, stream=None):
         events_qs = Event.objects.filter(sent_at__isnull=True)
@@ -80,7 +74,7 @@ class EventRelayer:
                 _capture_exception(exception)
 
                 if self.__stuck_on_error(event):
-                    warn_stuck_on_error(event)
+                    self.__warn_stuck_on_error(event)
                     return
 
             except (ModuleNotFoundError, AttributeError) as e:
@@ -90,7 +84,7 @@ class EventRelayer:
                 _capture_exception(e)
 
                 if self.__stuck_on_error(event):
-                    warn_stuck_on_error(event)
+                    self.__warn_stuck_on_error(event)
                     return
 
             except BaseException as e:
@@ -104,10 +98,15 @@ class EventRelayer:
                 _capture_exception(e)
 
                 if self.__stuck_on_error(event):
-                    warn_stuck_on_error(event)
+                    self.__warn_stuck_on_error(event)
                     return
 
     def __stuck_on_error(self, event):
         if not event.strategy:
             return settings.publish_strategy == PublishStrategyType.KEEP_ORDER
         return event.strategy == PublishStrategyType.KEEP_ORDER
+
+    def __warn_stuck_on_error(self, event):
+        logger.warning(
+            f"JAIMINHO-EVENTS-RELAY: Events relaying are stuck due to failing Event: {event}"
+        )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Release wasn't working because of an issue with `twine` and exploit was still applicable, since BadSignature errors were being catched and executed anyway inside the `try...except` block with `BaseException`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This will increase security for the library and allow releasing further upgrades.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Unit tests.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

RCE exploit is still applicable and release is failing.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

RCE exploit is not applicable anymore and releases are working again.

https://loadsmart.atlassian.net/browse/CT-2679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced exception handling with improved logging and conditional error recovery mechanisms.

* **Chores**
  * Updated release build tooling to pin specific dependency versions for stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->