### PR TITLE
fix: signal invocation called inside `try...except` block which might lead to undesired replay of message

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ from django.dispatch import receiver
 
 @receiver(event_published)
 def on_event_sent(sender, event_payload, **kwargs):
-    metrics.count(f"event_sent_successfully {event_payload.get('type')}")
+    metrics.count(f"event_sent_successfully: {event_payload}")
 
 @receiver(event_failed_to_publish)
 def on_event_send_error(sender, event_payload, **kwargs):
-    metrics.count(f"event_failed {event_payload.get('type')}")
+    metrics.count(f"event_failed: {event_payload}")
 
 ````
 

--- a/jaiminho/publish_strategies.py
+++ b/jaiminho/publish_strategies.py
@@ -97,8 +97,6 @@ def on_commit_hook(func, event, event_data, args, kwargs):
         logger.info(
             f"JAIMINHO-ON-COMMIT-HOOK: Event sent successfully. Payload: {args}"
         )
-
-        event_published.send(sender=func, event_payload=event_payload)
     except BaseException as exc:
         if not event:
             event = Event.objects.create(**event_data)
@@ -109,6 +107,8 @@ def on_commit_hook(func, event, event_data, args, kwargs):
         )
         event_failed_to_publish.send(sender=func, event_payload=event_payload)
         return
+    else:
+        event_published.send(sender=func, event_payload=event_payload)
 
     if event:
         if settings.delete_after_send:

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -63,10 +63,6 @@ class EventRelayer:
                     logger.info(
                         f"JAIMINHO-EVENTS-RELAY: Event marked as sent. Event: {event}, Payload: {args}"
                     )
-
-                event_published_by_events_relay.send(
-                    sender=original_fn, event_payload=event_payload
-                )
             except BadSignature as exception:
                 logger.warning(
                     f"JAIMINHO-EVENTS-RELAY: Event has been tampered, Event: {event}"
@@ -100,6 +96,10 @@ class EventRelayer:
                 if self.__stuck_on_error(event):
                     self.__warn_stuck_on_error(event)
                     return
+            else:
+                event_published_by_events_relay.send(
+                    sender=original_fn, event_payload=event_payload
+                )
 
     def __stuck_on_error(self, event):
         if not event.strategy:

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -39,6 +39,8 @@ class EventRelayer:
             return
 
         for event in events_qs:
+            event_payload = {}
+
             try:
                 event.verify_integrity()
                 args = dill.loads(event.message)

--- a/jaiminho_django_test_project/send.py
+++ b/jaiminho_django_test_project/send.py
@@ -17,6 +17,12 @@ def internal_notify(*args, decoder=None, **kwargs):
     print(args, kwargs)
 
 
+class ExampleClass:
+    @save_to_outbox
+    def notify(self, *args, **kwargs):
+        internal_notify(*args, **kwargs)
+
+
 @save_to_outbox
 def notify(*args, **kwargs):
     internal_notify(*args, **kwargs)

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -818,6 +818,31 @@ class TestValidateEventsRelay:
         "publish_strategy",
         (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
     )
+    def test_raise_exception_when_event_was_tampered(
+        self, mocker, caplog, mock_capture_exception_fn, publish_strategy
+    ):
+        mocker.patch(
+            "jaiminho.settings.default_capture_exception",
+            mock_capture_exception_fn,
+        )
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+
+        event = EventFactory.create()
+
+        Event.objects.all().update(message=b'')
+
+        call_command(validate_events_relay.Command())
+
+        assert "Event has been tampered" in caplog.text
+        capture_exception_call = mock_capture_exception_fn.call_args[0][0]
+        assert f"Event(id={event.id}) has been tampered" == str(
+            capture_exception_call
+        )
+
+    @pytest.mark.parametrize(
+        "publish_strategy",
+        (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
+    )
     def test_raise_exception_when_function_does_not_exist_anymore(
         self, caplog, publish_strategy, mocker
     ):

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -18,6 +18,7 @@ from jaiminho_django_test_project.send import (
     notify,
     notify_without_decorator,
     notify_to_stream,
+    ExampleClass,
 )
 
 pytestmark = pytest.mark.django_db
@@ -694,6 +695,35 @@ class TestValidateEventsRelay:
 
         mock_internal_notify.assert_called_once()
         mock_internal_notify.assert_called_with(args[0], encoder=DjangoJSONEncoder)
+        assert Event.objects.all().count() == 1
+        event = Event.objects.all()[0]
+        assert event.sent_at == datetime(2022, 10, 31, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        "publish_strategy",
+        (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
+    )
+    def test_relay_message_when_notify_function_is_class_method(
+        self,
+        mock_internal_notify,
+        mock_should_not_delete_after_send,
+        publish_strategy,
+        mocker,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+        example_class_instance = ExampleClass()
+        args = (example_class_instance, {"a": 1})
+        EventFactory(
+            function=dill.dumps(example_class_instance.notify),
+            message=dill.dumps(args),
+            kwargs=dill.dumps({"encoder": DjangoJSONEncoder}),
+        )
+
+        with freeze_time("2022-10-31"):
+            call_command(validate_events_relay.Command())
+
+        mock_internal_notify.assert_called_once()
+        mock_internal_notify.assert_called_with(args[1], encoder=DjangoJSONEncoder)
         assert Event.objects.all().count() == 1
         event = Event.objects.all()[0]
         assert event.sent_at == datetime(2022, 10, 31, tzinfo=UTC)

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -739,35 +739,6 @@ class TestValidateEventsRelay:
         "publish_strategy",
         (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
     )
-    def test_relay_message_when_notify_function_is_class_method(
-        self,
-        mock_internal_notify,
-        mock_should_not_delete_after_send,
-        publish_strategy,
-        mocker,
-    ):
-        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
-        example_class_instance = ExampleClass()
-        args = (example_class_instance, {"a": 1})
-        EventFactory(
-            function=dill.dumps(example_class_instance.notify),
-            message=dill.dumps(args),
-            kwargs=dill.dumps({"encoder": DjangoJSONEncoder}),
-        )
-
-        with freeze_time("2022-10-31"):
-            call_command(validate_events_relay.Command())
-
-        mock_internal_notify.assert_called_once()
-        mock_internal_notify.assert_called_with(args[1], encoder=DjangoJSONEncoder)
-        assert Event.objects.all().count() == 1
-        event = Event.objects.all()[0]
-        assert event.sent_at == datetime(2022, 10, 31, tzinfo=UTC)
-
-    @pytest.mark.parametrize(
-        "publish_strategy",
-        (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
-    )
     def test_dont_create_another_event_when_relay_fails(
         self,
         failed_event,

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -829,15 +829,13 @@ class TestValidateEventsRelay:
 
         event = EventFactory.create()
 
-        Event.objects.all().update(message=b'')
+        Event.objects.all().update(message=b"")
 
         call_command(validate_events_relay.Command())
 
         assert "Event has been tampered" in caplog.text
         capture_exception_call = mock_capture_exception_fn.call_args[0][0]
-        assert f"Event(id={event.id}) has been tampered" == str(
-            capture_exception_call
-        )
+        assert f"Event(id={event.id}) has been tampered" == str(capture_exception_call)
 
     @pytest.mark.parametrize(
         "publish_strategy",

--- a/jaiminho_django_test_project/tests/test_send.py
+++ b/jaiminho_django_test_project/tests/test_send.py
@@ -73,6 +73,41 @@ class TestNotify:
         "publish_strategy",
         (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
     )
+    def test_send_from_class_method_successfully_persists_event(
+        self,
+        mock_internal_notify,
+        mock_log_metric,
+        mock_should_not_delete_after_send,
+        mock_should_persist_all_events,
+        publish_strategy,
+        caplog,
+        mocker,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+        example_class_instance = jaiminho_django_test_project.send.ExampleClass()
+
+        payload_1 = {"key": "value"}
+        payload_2 = "value"
+        payload_3 = {"another-key": "another-value"}
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            example_class_instance.notify(*(payload_1, payload_2), **payload_3)
+
+        assert Event.objects.all().count() == 1
+
+        event = Event.objects.first()
+        kwargs = dill.loads(event.kwargs)
+        args = dill.loads(event.message)
+
+        assert kwargs == payload_3
+        assert args[0].__dict__ == example_class_instance.__dict__
+        assert args[1:] == (payload_1, payload_2)
+        assert event.stream is None
+        assert "JAIMINHO-SAVE-TO-OUTBOX: Event created" in caplog.text
+
+    @pytest.mark.parametrize(
+        "publish_strategy",
+        (PublishStrategyType.PUBLISH_ON_COMMIT, PublishStrategyType.KEEP_ORDER),
+    )
     def test_send_success_should_persist_all_events(
         self,
         mock_internal_notify,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Signals being sent inside `try...except` block were moved outside of its scope to avoid a possible failure or replay due to subsequent invocations.

Payload passed to signals were kept the same, but documentation was updated to avoid leading users into errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Improve security of the library. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Unit and integration tests.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Messages are being replayed when there are failures on signals.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Messages won't be replayed when there are failures on signals.


https://loadsmart.atlassian.net/browse/CT-2459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event publication signals to fire only when operations complete successfully, not when exceptions occur.

* **Documentation**
  * Updated metrics collection examples in README to reflect current labeling and payload handling practices.

* **Tests**
  * Added tests for class method notification handling and event tampering detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->