### PR TITLE
fix: lock rows when relaying events

### DIFF
--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -29,9 +29,8 @@ def _extract_original_func(event):
 
 class EventRelayer:
     def relay(self, stream=None):
-        events_qs = Event.objects.filter(sent_at__isnull=True)
+        events_qs = Event.objects.select_for_update(skip_locked=True).filter(sent_at__isnull=True)
         events_qs = events_qs.filter(stream=stream)
-
         events_qs = events_qs.order_by("created_at")
 
         if not events_qs:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Lock rows when picking events to relay.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This will prevent duplicate events being relayed in environments with multiple workers.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

I haven't found a reliable way to test this behavior.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Event rows of unsent events aren't being locked when events are relayed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Event rows of unsent events are being locked when relay process is started.

https://loadsmart.atlassian.net/browse/CT-2458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of concurrent event relaying. When multiple workers process events simultaneously, the system now uses enhanced database-level coordination to prevent conflicts and race conditions. This ensures consistent and reliable event delivery, with better performance and stability in high-concurrency production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->