### PR TITLE
fix: add transaction atomic block to relay method

### DIFF
--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -2,6 +2,7 @@ import logging
 import dill
 
 from django.core.signing import BadSignature
+from django.db import transaction
 
 from jaiminho.constants import PublishStrategyType
 from jaiminho.models import Event
@@ -29,6 +30,7 @@ def _extract_original_func(event):
 
 class EventRelayer:
     def relay(self, stream=None):
+        skip_locked = settings.publish_strategy == PublishStrategyType.PUBLISH_ON_COMMIT
         events_qs = Event.objects.filter(sent_at__isnull=True)
         events_qs = events_qs.filter(stream=stream)
 
@@ -39,69 +41,87 @@ class EventRelayer:
             return
 
         for event in events_qs:
+            event_id = event.id
             event_payload = {}
 
-            try:
-                event.verify_integrity()
-                args = dill.loads(event.message)
-                kwargs = dill.loads(event.kwargs) if event.kwargs else {}
-                event_payload = get_event_payload(args)
-
-                original_fn = _extract_original_func(event)
-                if isinstance(args, tuple):
-                    original_fn(*args, **kwargs)
-                else:
-                    original_fn(args, **kwargs)
-
-                logger.info(f"JAIMINHO-EVENTS-RELAY: Event sent. Event {event}")
-
-                if settings.delete_after_send:
-                    event.delete()
-                    logger.info(
-                        f"JAIMINHO-EVENTS-RELAY: Event deleted after success send. Event: {event}, Payload: {args}"
+            with transaction.atomic():
+                try:
+                    event = (
+                        Event.objects.select_for_update(skip_locked=skip_locked)
+                        .filter(sent_at__isnull=True, id=event.id)
+                        .first()
                     )
-                else:
-                    event.mark_as_sent()
-                    logger.info(
-                        f"JAIMINHO-EVENTS-RELAY: Event marked as sent. Event: {event}, Payload: {args}"
+
+                    if not event:
+                        logger.info(
+                            f"JAIMINHO-EVENTS-RELAY: Event {event_id} already handled by another worker, skipping."
+                        )
+                        continue
+
+                    event.verify_integrity()
+                    args = dill.loads(event.message)
+                    kwargs = dill.loads(event.kwargs) if event.kwargs else {}
+                    event_payload = get_event_payload(args)
+
+                    original_fn = _extract_original_func(event)
+                    if isinstance(args, tuple):
+                        original_fn(*args, **kwargs)
+                    else:
+                        original_fn(args, **kwargs)
+
+                    logger.info(f"JAIMINHO-EVENTS-RELAY: Event sent. Event {event}")
+
+                    if settings.delete_after_send:
+                        event.delete()
+                        logger.info(
+                            f"JAIMINHO-EVENTS-RELAY: Event deleted after success send. Event: {event}, Payload: {args}"
+                        )
+                    else:
+                        event.mark_as_sent()
+                        logger.info(
+                            f"JAIMINHO-EVENTS-RELAY: Event marked as sent. Event: {event}, Payload: {args}"
+                        )
+
+                    transaction.on_commit(
+                        lambda: event_published_by_events_relay.send(
+                            sender=original_fn, event_payload=event_payload
+                        )
                     )
-            except BadSignature as exception:
-                logger.warning(
-                    f"JAIMINHO-EVENTS-RELAY: Event has been tampered, Event: {event}"
-                )
-                _capture_exception(exception)
+                except BadSignature as exception:
+                    logger.warning(
+                        f"JAIMINHO-EVENTS-RELAY: Event has been tampered, Event: {event}"
+                    )
+                    _capture_exception(exception)
 
-                if self.__stuck_on_error(event):
-                    self.__warn_stuck_on_error(event)
-                    return
+                    if self.__stuck_on_error(event):
+                        self.__warn_stuck_on_error(event)
+                        return
 
-            except (ModuleNotFoundError, AttributeError) as e:
-                logger.warning(
-                    f"JAIMINHO-EVENTS-RELAY: Function does not exist anymore, Event: {event} | Error: {str(e)}"
-                )
-                _capture_exception(e)
+                except (ModuleNotFoundError, AttributeError) as e:
+                    logger.warning(
+                        f"JAIMINHO-EVENTS-RELAY: Function does not exist anymore, Event: {event} | Error: {str(e)}"
+                    )
+                    _capture_exception(e)
 
-                if self.__stuck_on_error(event):
-                    self.__warn_stuck_on_error(event)
-                    return
+                    if self.__stuck_on_error(event):
+                        self.__warn_stuck_on_error(event)
+                        return
 
-            except BaseException as e:
-                logger.warning(
-                    f"JAIMINHO-EVENTS-RELAY: An error occurred when relaying event: {event} | Error: {str(e)}"
-                )
-                original_fn = _extract_original_func(event)
-                event_failed_to_publish_by_events_relay.send(
-                    sender=original_fn, event_payload=event_payload
-                )
-                _capture_exception(e)
+                except BaseException as e:
+                    logger.warning(
+                        f"JAIMINHO-EVENTS-RELAY: An error occurred when relaying event: {event} | Error: {str(e)}"
+                    )
+                    original_fn = _extract_original_func(event)
+                    transaction.on_commit(
+                        lambda: event_failed_to_publish_by_events_relay.send(
+                            sender=original_fn, event_payload=event_payload
+                        )
+                    )
+                    _capture_exception(e)
 
-                if self.__stuck_on_error(event):
-                    self.__warn_stuck_on_error(event)
-                    return
-            else:
-                event_published_by_events_relay.send(
-                    sender=original_fn, event_payload=event_payload
-                )
+                    if self.__stuck_on_error(event):
+                        self.__warn_stuck_on_error(event)
+                        return
 
     def __stuck_on_error(self, event):
         if not event.strategy:

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -8,7 +8,6 @@ from dateutil.tz import UTC
 from django.core.management import call_command
 from django.core.serializers.json import DjangoJSONEncoder
 from freezegun import freeze_time
-
 from jaiminho.constants import PublishStrategyType
 from jaiminho.signals import get_event_payload
 from jaiminho.models import Event
@@ -19,7 +18,6 @@ from jaiminho_django_test_project.send import (
     notify,
     notify_without_decorator,
     notify_to_stream,
-    ExampleClass,
 )
 
 pytestmark = pytest.mark.django_db
@@ -364,11 +362,14 @@ class TestValidateEventsRelay:
         mock_event_published_signal,
         publish_strategy,
         mocker,
+        django_capture_on_commit_callbacks,
     ):
         mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
 
-        call_command(validate_events_relay.Command())
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            call_command(validate_events_relay.Command())
 
+        assert len(callbacks) == 1
         mock_internal_notify.assert_called_once()
         mock_event_published_signal.assert_not_called()
         expected_args = dill.loads(failed_event.message)
@@ -389,11 +390,14 @@ class TestValidateEventsRelay:
         mock_event_published_signal,
         publish_strategy,
         mocker,
+        django_capture_on_commit_callbacks,
     ):
         mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
 
-        call_command(validate_events_relay.Command())
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            call_command(validate_events_relay.Command())
 
+        assert len(callbacks) == 1
         mock_internal_notify.assert_called_once()
         mock_event_published_signal.assert_not_called()
         expected_args = dill.loads(failed_event_with_kwargs.message)
@@ -414,11 +418,14 @@ class TestValidateEventsRelay:
         mock_event_failed_to_publish_signal,
         publish_strategy,
         mocker,
+        django_capture_on_commit_callbacks,
     ):
         mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
 
-        call_command(validate_events_relay.Command())
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            call_command(validate_events_relay.Command())
 
+        assert len(callbacks) == 1
         mock_internal_notify_fail.assert_called_once()
         mock_event_failed_to_publish_signal.assert_not_called()
         expected_args = dill.loads(failed_event.message)
@@ -439,11 +446,14 @@ class TestValidateEventsRelay:
         mock_event_failed_to_publish_signal,
         publish_strategy,
         mocker,
+        django_capture_on_commit_callbacks,
     ):
         mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
 
-        call_command(validate_events_relay.Command())
+        with django_capture_on_commit_callbacks(execute=True) as callbacks:
+            call_command(validate_events_relay.Command())
 
+        assert len(callbacks) == 1
         mock_internal_notify_fail.assert_called_once()
         mock_event_failed_to_publish_signal.assert_not_called()
         expected_args = dill.loads(failed_event_with_kwargs.message)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Lock rows when picking events to relay.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This will prevent duplicate events being relayed in environments with multiple workers.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Unit.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Event rows of unsent events aren't being locked when events are relayed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Event rows of unsent events are being locked when relay process is started.

https://loadsmart.atlassian.net/browse/CT-2458



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing pending events by reducing duplicate handling during concurrent runs.
  - Event delivery now uses safer locking, helping prevent the same item from being processed more than once at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->