### PR TITLE
revert: lock rows when relaying events

### DIFF
--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -29,8 +29,9 @@ def _extract_original_func(event):
 
 class EventRelayer:
     def relay(self, stream=None):
-        events_qs = Event.objects.select_for_update(skip_locked=True).filter(sent_at__isnull=True)
+        events_qs = Event.objects.filter(sent_at__isnull=True)
         events_qs = events_qs.filter(stream=stream)
+
         events_qs = events_qs.order_by("created_at")
 
         if not events_qs:


### PR DESCRIPTION
Reverts loadsmart/django-jaiminho#244

Since it's missing atomic block it will fail. Also, adding an atomic block has other implications. Beyond that, the `skip_lock=True` will make events be unordered, even when using the `KEEP_ORDER` strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event delivery consistency by changing how pending events are picked up for processing. This reduces missed work in some concurrent relaying scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->