### PR TITLE
fix: move event publish to end of on_commit_hook

### DIFF
--- a/jaiminho/publish_strategies.py
+++ b/jaiminho/publish_strategies.py
@@ -107,8 +107,6 @@ def on_commit_hook(func, event, event_data, args, kwargs):
         )
         event_failed_to_publish.send(sender=func, event_payload=event_payload)
         return
-    else:
-        event_published.send(sender=func, event_payload=event_payload)
 
     if event:
         if settings.delete_after_send:
@@ -121,3 +119,5 @@ def on_commit_hook(func, event, event_data, args, kwargs):
                 f"JAIMINHO-ON-COMMIT-HOOK: Event marked as sent. Event: {event}, Payload: {args}"
             )
             event.mark_as_sent()
+
+    event_published.send(sender=func, event_payload=event_payload)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This will prevent the signal to send events which might fail later.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

It complements https://github.com/loadsmart/django-jaiminho/pull/243.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Unit.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Signal is being called before event is marked as sent.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Signal will be dispatched only after it is mark as sent.

 https://loadsmart.atlassian.net/browse/CT-2459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event publishing reliability so successful publishes are confirmed after post-processing steps complete.
  * Failure handling remains intact, including recovery behavior and failure notifications when publishing cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->