### PR TITLE
fix: support writes to other database

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ def any_external_call(**kwargs):
     return
 ```
 
+If your project writes to more than one database, pass the alias your decorated function's transaction runs on through the `using` argument, so the outbox event is persisted and the on-commit hook is bound to that same alias:
+
+```python
+from jaiminho.send import save_to_outbox
+
+@save_to_outbox(using="replica")
+def any_external_call(**kwargs):
+    # do something
+    return
+```
+
+`@save_to_outbox_stream` accepts the same `using` argument. When omitted, Jaiminho keeps its previous behavior of relying on Django's default database alias.
+
 ### 6 - Run the relay events command
 
 ```

--- a/jaiminho/publish_strategies.py
+++ b/jaiminho/publish_strategies.py
@@ -28,12 +28,12 @@ def create_event_data(func, args, kwargs, strategy, stream=None):
 
 class BaseStrategy(ABC):
     @abstractmethod
-    def publish(self, args, kwargs, func, stream=None):
+    def publish(self, args, kwargs, func, stream=None, using=None):
         raise NotImplementedError
 
 
 class PublishOnCommitStrategy(BaseStrategy):
-    def publish(self, args, kwargs, func, stream=None):
+    def publish(self, args, kwargs, func, stream=None, using=None):
         event_data = create_event_data(
             func,
             args,
@@ -44,7 +44,7 @@ class PublishOnCommitStrategy(BaseStrategy):
 
         event = None
         if settings.persist_all_events:
-            event = Event.objects.create(**event_data)
+            event = Event.objects.using(using).create(**event_data)
             logger.info(
                 f"JAIMINHO-SAVE-TO-OUTBOX: Event created: Event {event}, Payload: {args}"
             )
@@ -55,15 +55,18 @@ class PublishOnCommitStrategy(BaseStrategy):
             "event": event,
             "args": args,
             "kwargs": kwargs,
+            "using": using,
         }
-        transaction.on_commit(lambda: on_commit_hook(**on_commit_hook_kwargs))
+        transaction.on_commit(
+            lambda: on_commit_hook(**on_commit_hook_kwargs), using=using
+        )
         logger.info(
             f"JAIMINHO-SAVE-TO-OUTBOX: On commit hook configured. Event: {event}"
         )
 
 
 class KeepOrderStrategy(BaseStrategy):
-    def publish(self, args, kwargs, func, stream=None):
+    def publish(self, args, kwargs, func, stream=None, using=None):
         event_data = create_event_data(
             func,
             args,
@@ -71,7 +74,7 @@ class KeepOrderStrategy(BaseStrategy):
             PublishStrategyType.KEEP_ORDER,
             stream=stream,
         )
-        event = Event.objects.create(**event_data)
+        event = Event.objects.using(using).create(**event_data)
         logger.info(
             f"JAIMINHO-SAVE-TO-OUTBOX: Event created: Event {event}, Payload: {args}"
         )
@@ -89,7 +92,7 @@ def create_publish_strategy(strategy_type):
         raise ValueError(f"Unknow strategy type: {strategy_type}")
 
 
-def on_commit_hook(func, event, event_data, args, kwargs):
+def on_commit_hook(func, event, event_data, args, kwargs, using=None):
     event_payload = get_event_payload(args)
 
     try:
@@ -99,7 +102,7 @@ def on_commit_hook(func, event, event_data, args, kwargs):
         )
     except BaseException as exc:
         if not event:
-            event = Event.objects.create(**event_data)
+            event = Event.objects.using(using).create(**event_data)
 
         logger.warning(
             f"JAIMINHO-ON-COMMIT-HOOK: Event failed to be published. Event: {event}, Payload: {args}, "

--- a/jaiminho/send.py
+++ b/jaiminho/send.py
@@ -4,21 +4,26 @@ from functools import wraps
 logger = logging.getLogger(__name__)
 
 
-def save_to_outbox(func):
-    @wraps(func)
-    def inner(*args, **kwargs):
-        # Load Django dependencies lazily to ensure the Django environment is ready
-        from jaiminho.publish_strategies import create_publish_strategy
-        from jaiminho import settings
+def save_to_outbox(func=None, *, using=None):
+    def decorator(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            # Load Django dependencies lazily to ensure the Django environment is ready
+            from jaiminho.publish_strategies import create_publish_strategy
+            from jaiminho import settings
 
-        publish_strategy = create_publish_strategy(settings.publish_strategy)
-        publish_strategy.publish(args, kwargs, func)
+            publish_strategy = create_publish_strategy(settings.publish_strategy)
+            publish_strategy.publish(args, kwargs, func, using=using)
 
-    inner.original_func = func
-    return inner
+        inner.original_func = func
+        return inner
+
+    if func is not None:
+        return decorator(func)
+    return decorator
 
 
-def save_to_outbox_stream(stream, overwrite_strategy_with=None):
+def save_to_outbox_stream(stream, overwrite_strategy_with=None, using=None):
     def decorator(func):
         @wraps(func)
         def inner(*args, **kwargs):
@@ -32,7 +37,7 @@ def save_to_outbox_stream(stream, overwrite_strategy_with=None):
                 else settings.publish_strategy
             )
             publish_strategy = create_publish_strategy(_publish_strategy)
-            publish_strategy.publish(args, kwargs, func, stream)
+            publish_strategy.publish(args, kwargs, func, stream, using=using)
 
         inner.original_func = func
         return inner

--- a/jaiminho_django_test_project/send.py
+++ b/jaiminho_django_test_project/send.py
@@ -48,4 +48,21 @@ def notify_without_decorator(*args, **kwargs):
     internal_notify(*args, **kwargs)
 
 
+@save_to_outbox(using="secondary")
+def notify_using_secondary_db(*args, **kwargs):
+    internal_notify(*args, **kwargs)
+
+
+@save_to_outbox_stream(EXAMPLE_STREAM, using="secondary")
+def notify_to_stream_using_secondary_db(*args, **kwargs):
+    internal_notify(*args, **kwargs)
+
+
+@save_to_outbox_stream(
+    EXAMPLE_STREAM, PublishStrategyType.KEEP_ORDER, using="secondary"
+)
+def notify_keep_order_using_secondary_db(*args, **kwargs):
+    internal_notify(*args, **kwargs)
+
+
 __all__ = ("notify", "notify_without_decorator")

--- a/jaiminho_django_test_project/settings.py
+++ b/jaiminho_django_test_project/settings.py
@@ -81,7 +81,11 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": BASE_DIR / "db.sqlite3",
-    }
+    },
+    "secondary": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db_secondary.sqlite3",
+    },
 }
 
 

--- a/jaiminho_django_test_project/tests/test_send.py
+++ b/jaiminho_django_test_project/tests/test_send.py
@@ -927,3 +927,61 @@ class TestNofityWithStreamOverwritingStrategy:
         )
         assert Event.objects.all().count() == 1
         assert Event.objects.get().strategy == PublishStrategyType.KEEP_ORDER
+
+
+@pytest.mark.django_db(databases=["default", "secondary"])
+class TestNotifyUsingDatabaseAlias:
+    def test_publish_on_commit_persists_event_to_the_given_alias(
+        self, mock_internal_notify, mock_should_persist_all_events
+    ):
+        args = ({"action": "a"},)
+        with TestCase.captureOnCommitCallbacks(using="secondary", execute=True):
+            jaiminho_django_test_project.send.notify_using_secondary_db(*args)
+
+        assert Event.objects.using("secondary").count() == 1
+        assert Event.objects.using("default").count() == 0
+        mock_internal_notify.assert_called_once_with(*args)
+
+    def test_publish_on_commit_stream_persists_event_to_the_given_alias(
+        self, mock_internal_notify, mock_should_persist_all_events
+    ):
+        args = ({"action": "a"},)
+        with TestCase.captureOnCommitCallbacks(using="secondary", execute=True):
+            jaiminho_django_test_project.send.notify_to_stream_using_secondary_db(*args)
+
+        event = Event.objects.using("secondary").get()
+        assert event.stream == jaiminho_django_test_project.send.EXAMPLE_STREAM
+        assert Event.objects.using("default").count() == 0
+        mock_internal_notify.assert_called_once_with(*args)
+
+    def test_keep_order_persists_event_to_the_given_alias(self, mock_internal_notify):
+        args = ({"action": "a"},)
+        jaiminho_django_test_project.send.notify_keep_order_using_secondary_db(*args)
+
+        event = Event.objects.using("secondary").get()
+        assert event.strategy == PublishStrategyType.KEEP_ORDER
+        assert Event.objects.using("default").count() == 0
+
+    def test_on_commit_hook_failure_creates_event_on_the_given_alias(self, mocker):
+        mocker.patch(
+            "jaiminho_django_test_project.send.internal_notify",
+            autospec=True,
+            side_effect=Exception("boom"),
+        )
+
+        args = ({"action": "a"},)
+        with TestCase.captureOnCommitCallbacks(using="secondary", execute=True):
+            jaiminho_django_test_project.send.notify_using_secondary_db(*args)
+
+        assert Event.objects.using("secondary").count() == 1
+        assert Event.objects.using("default").count() == 0
+
+    def test_default_alias_is_unaffected_when_using_is_not_provided(
+        self, mock_internal_notify, mock_should_persist_all_events
+    ):
+        args = ({"action": "a"},)
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            jaiminho_django_test_project.send.notify(*args)
+
+        assert Event.objects.using("default").count() == 1
+        assert Event.objects.using("secondary").count() == 0


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Enables using other database to write events.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Writes are always done at the default database, without option for other aliases. This will fail on systems that use multiple databases (write sharding). 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->

Unit tests.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Can't save events to other databases than just the "default" one.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Saving events to other databases than just "default" one is supported through the "using" parameter.

https://loadsmart.atlassian.net/browse/CT-2457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting a specific database when saving events to the outbox.
  - Stream-based outbox publishing now supports database selection as well.
  - Event publishing, ordering, and failure handling consistently use the selected database.

- **Documentation**
  - Updated usage guidance with examples for database-specific outbox operations.
  - Clarified default database behavior when no database is specified.

- **Tests**
  - Added coverage confirming events are stored in the selected database and default behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->