### PR TITLE
[CT-2898] Stop retrying non-transient errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Calendar Versioning](https://calver.org/) following
 the schema `YYYY.MM.DD.N` been `N` the number of the release of the day.
 
 ## [Unreleased]
+### Added
+- `NON_RETRYABLE_EXCEPTIONS` setting: events that fail with a configured exception (defaults to `BadSignature`, `ModuleNotFoundError`, `AttributeError`) are no longer retried forever - they're dropped instead of persisted, preventing a single permanently-failing event from poisoning the outbox or blocking the Keep Order relay. [CT-2898]
 
 ## [2.1.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ the schema `YYYY.MM.DD.N` been `N` the number of the release of the day.
 
 ## [Unreleased]
 ### Added
-- `NON_RETRYABLE_EXCEPTIONS` setting: events that fail with a configured exception (defaults to `BadSignature`, `ModuleNotFoundError`, `AttributeError`) are no longer retried forever - they're dropped instead of persisted, preventing a single permanently-failing event from poisoning the outbox or blocking the Keep Order relay. [CT-2898]
+- `NON_RETRYABLE_EXCEPTIONS` setting: events that fail with a configured exception (defaults to `BadSignature`, `ModuleNotFoundError`, `AttributeError`) are no longer retried forever under the Publish on Commit strategy - they're dropped instead of persisted, preventing a single permanently-failing event from poisoning the outbox. Keep Order is unaffected: it still gets stuck on these failures to preserve delivery order. [CT-2898]
 
 ## [2.1.0] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,15 @@ Some errors, however, are not transient: if the decorated function raises one of
 - `DEFAULT_ENCODER` - Default Encoder for the payload (overwritable in the function call)
 - `SIGN_EVENTS` - Signs events to support verification later
 - `VERIFY_EVENTS_SIGNATURE` - Verifies previously generated signatures
-- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
+- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)` (importable as `jaiminho.errors.DEFAULT_NON_RETRYABLE_EXCEPTIONS`). Setting this **replaces** the default tuple rather than extending it, so if you want the built-ins covered too, compose them explicitly:
+
+  ```python
+  from jaiminho.errors import DEFAULT_NON_RETRYABLE_EXCEPTIONS
+
+  JAIMINHO_CONFIG = {
+      "NON_RETRYABLE_EXCEPTIONS": DEFAULT_NON_RETRYABLE_EXCEPTIONS + (MyAppPermanentError,),
+  }
+  ```
 
 ### Strategies
 
@@ -224,7 +232,7 @@ Here's how to implement this:
 
 ```python
 from celery import Celery
-from jaiminho import save_to_outbox
+from jaiminho.send import save_to_outbox
 
 
 class CeleryWithJaiminho(Celery):

--- a/README.md
+++ b/README.md
@@ -190,10 +190,14 @@ In the example above, `True` is the option for run_in_loop; `0.1` for loop_inter
 
 Jaiminho triggers the following Django signals:
 
-| Signal                  | Description                                                                     |
-|-------------------------|---------------------------------------------------------------------------------|
-| event_published         | Triggered when an event is sent successfully                                    |
-| event_failed_to_publish | Triggered when an event is not sent, being added to the Outbox table queue      |
+| Signal                                       | Description                                                                                                                     |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| event_published                              | Triggered when an event is sent successfully                                                                                    |
+| event_failed_to_publish                      | Triggered when an event is not sent, being added to the Outbox table queue                                                      |
+| event_permanently_failed                     | Triggered by `@save_to_outbox`'s on-commit hook when the decorated function raises one of `NON_RETRYABLE_EXCEPTIONS`; the event is dropped (or deleted, if already persisted) instead of being retried |
+| event_permanently_failed_by_events_relay     | Triggered by the `events_relay` command when a relayed event fails with one of `NON_RETRYABLE_EXCEPTIONS`; the event is given up on instead of being retried |
+
+All of the signals above are sent with `sender` (the original decorated function, or `None` if it could not be resolved) and `event_payload` (the first positional argument passed to the decorated function, or `{}` if there wasn't one).
 
 
 ### How to collect metrics from Jaiminho?

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you don't use `--run-in-loop` option, the relay command will run only 1 time.
 
 Jaiminho `@save_to_outbox` decorator will **intercept** decorated function and **persist** it in a **database table** in the same **transaction** that is active in the decorated function context. The event relay **command**, is a **separated process** that fetches the rows from this table and execute the functions. When an outage happens, the event relay command will **keep retrying until it succeeds**. This way, **eventual consistency is ensured** by design.
 
-Some errors, however, are not transient: if the decorated function raises one of the exceptions configured through `NON_RETRYABLE_EXCEPTIONS` (`BadSignature`, `ModuleNotFoundError` and `AttributeError` by default), retrying is guaranteed to fail again in the exact same way. Jaiminho does not persist an event for these failures (or deletes it if it was already persisted), so a single permanently-failing event can no longer poison the outbox table or, under the **Keep Order** strategy, block every event queued behind it.
+Some errors, however, are not transient: if the decorated function raises one of the exceptions configured through `NON_RETRYABLE_EXCEPTIONS` (`BadSignature`, `ModuleNotFoundError` and `AttributeError` by default), retrying is guaranteed to fail again in the exact same way. Under the **Publish on Commit** strategy, Jaiminho does not persist an event for these failures (or deletes it if it was already persisted), so a single permanently-failing event can no longer poison the outbox table. Under the **Keep Order** strategy this behavior does not apply: dropping an event would break delivery order for whatever is queued behind it, so a non-retryable failure still gets the relayer stuck, same as any other failure.
 
 ### Configuration options
 
@@ -100,13 +100,13 @@ Some errors, however, are not transient: if the decorated function raises one of
 - `DEFAULT_ENCODER` - Default Encoder for the payload (overwritable in the function call)
 - `SIGN_EVENTS` - Signs events to support verification later
 - `VERIFY_EVENTS_SIGNATURE` - Verifies previously generated signatures
-- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
+- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Only applies to the `publish-on-commit` strategy; under `keep-order` these failures still get the relayer stuck, to preserve delivery order. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
 
 ### Strategies
 
 #### Keep Order
 This strategy is similar to transactional outbox [described by Chris Richardson](https://microservices.io/patterns/data/transactional-outbox.html). The decorated function intercepts the function call and saves it on the local DB to be executed later. A separate command relayer will keep polling local DB and executing those functions in the same order it was stored. 
-Be carefully with this approach, **if any execution fails, the relayer will get stuck** as it would not be possible to guarantee delivery order.  
+Be carefully with this approach, **if any execution fails, the relayer will get stuck** as it would not be possible to guarantee delivery order. This includes failures configured as `NON_RETRYABLE_EXCEPTIONS` - they are not dropped under this strategy, precisely because doing so would break the order guarantee.
 
 #### Publish on commit
 
@@ -195,7 +195,7 @@ Jaiminho triggers the following Django signals:
 | event_published                              | Triggered when an event is sent successfully                                                                                    |
 | event_failed_to_publish                      | Triggered when an event is not sent, being added to the Outbox table queue                                                      |
 | event_permanently_failed                     | Triggered by `@save_to_outbox`'s on-commit hook when the decorated function raises one of `NON_RETRYABLE_EXCEPTIONS`; the event is dropped (or deleted, if already persisted) instead of being retried |
-| event_permanently_failed_by_events_relay     | Triggered by the `events_relay` command when a relayed event fails with one of `NON_RETRYABLE_EXCEPTIONS`; the event is given up on instead of being retried |
+| event_permanently_failed_by_events_relay     | Triggered by the `events_relay` command when a relayed event fails with one of `NON_RETRYABLE_EXCEPTIONS`; the event is given up on instead of being retried. Only fires for events using the `publish-on-commit` strategy - under `keep-order` the relayer gets stuck instead |
 
 All of the signals above are sent with `sender` (the original decorated function, or `None` if it could not be resolved) and `event_payload` (the first positional argument passed to the decorated function, or `{}` if there wasn't one).
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ If you don't use `--run-in-loop` option, the relay command will run only 1 time.
 
 Jaiminho `@save_to_outbox` decorator will **intercept** decorated function and **persist** it in a **database table** in the same **transaction** that is active in the decorated function context. The event relay **command**, is a **separated process** that fetches the rows from this table and execute the functions. When an outage happens, the event relay command will **keep retrying until it succeeds**. This way, **eventual consistency is ensured** by design.
 
+Some errors, however, are not transient: if the decorated function raises one of the exceptions configured through `NON_RETRYABLE_EXCEPTIONS` (`BadSignature`, `ModuleNotFoundError` and `AttributeError` by default), retrying is guaranteed to fail again in the exact same way. Jaiminho does not persist an event for these failures (or deletes it if it was already persisted), so a single permanently-failing event can no longer poison the outbox table or, under the **Keep Order** strategy, block every event queued behind it.
+
 ### Configuration options
 
 - `PUBLISH_STRATEGY` - Strategy used to publish events (publish-on-commit, keep-order)
@@ -98,6 +100,7 @@ Jaiminho `@save_to_outbox` decorator will **intercept** decorated function and *
 - `DEFAULT_ENCODER` - Default Encoder for the payload (overwritable in the function call)
 - `SIGN_EVENTS` - Signs events to support verification later
 - `VERIFY_EVENTS_SIGNATURE` - Verifies previously generated signatures
+- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
 
 ### Strategies
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Some errors, however, are not transient: if the decorated function raises one of
 - `VERIFY_EVENTS_SIGNATURE` - Verifies previously generated signatures
 - `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Only applies to the `publish-on-commit` strategy; under `keep-order` these failures still get the relayer stuck, to preserve delivery order. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
 
+#### Non-retryable exceptions in detail
+
+- **`BadSignature`** - stored signature doesn't match the payload (`VERIFY_EVENTS_SIGNATURE`). Usually tampering, or signing config (`SECRET_KEY`, `SIGN_EVENTS`) changed after the event was persisted.
+- **`ModuleNotFoundError`** / **`AttributeError`** - the outbox stores a `dill` reference to the decorated function's module path, not its source. The relay re-imports that path when it runs. If the function's module is later moved/renamed (`ModuleNotFoundError`) or the function itself is renamed/removed (`AttributeError`), any event already persisted under the old code will fail to deserialize.
+
+**Risk:** deploying such a move/rename while events are still waiting to be relayed can lose them - they're dropped as non-retryable instead of retried. Only affects `publish-on-commit` (in-flight events); `keep-order` never drops non-retryable failures, it just gets stuck. Low-probability but real; mitigate by draining the outbox before the deploy, or excluding these two from `NON_RETRYABLE_EXCEPTIONS` for it.
+
 ### Strategies
 
 #### Keep Order

--- a/README.md
+++ b/README.md
@@ -100,15 +100,7 @@ Some errors, however, are not transient: if the decorated function raises one of
 - `DEFAULT_ENCODER` - Default Encoder for the payload (overwritable in the function call)
 - `SIGN_EVENTS` - Signs events to support verification later
 - `VERIFY_EVENTS_SIGNATURE` - Verifies previously generated signatures
-- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)` (importable as `jaiminho.errors.DEFAULT_NON_RETRYABLE_EXCEPTIONS`). Setting this **replaces** the default tuple rather than extending it, so if you want the built-ins covered too, compose them explicitly:
-
-  ```python
-  from jaiminho.errors import DEFAULT_NON_RETRYABLE_EXCEPTIONS
-
-  JAIMINHO_CONFIG = {
-      "NON_RETRYABLE_EXCEPTIONS": DEFAULT_NON_RETRYABLE_EXCEPTIONS + (MyAppPermanentError,),
-  }
-  ```
+- `NON_RETRYABLE_EXCEPTIONS` - Tuple of exception classes that are never retried: an event that fails with one of these is dropped instead of being persisted for retry. Defaults to `(BadSignature, ModuleNotFoundError, AttributeError)`. Setting this **replaces** the default tuple rather than extending it, so include those three as well if you still want them covered.
 
 ### Strategies
 

--- a/jaiminho/errors.py
+++ b/jaiminho/errors.py
@@ -1,0 +1,9 @@
+from django.core.signing import BadSignature
+
+DEFAULT_NON_RETRYABLE_EXCEPTIONS = (BadSignature, ModuleNotFoundError, AttributeError)
+
+
+def is_non_retryable(exception):
+    from jaiminho import settings
+
+    return isinstance(exception, settings.non_retryable_exceptions)

--- a/jaiminho/publish_strategies.py
+++ b/jaiminho/publish_strategies.py
@@ -5,8 +5,14 @@ import dill
 from django.db import transaction
 
 from jaiminho.constants import PublishStrategyType
+from jaiminho.errors import is_non_retryable
 from jaiminho.models import Event
-from jaiminho.signals import event_published, event_failed_to_publish, get_event_payload
+from jaiminho.signals import (
+    event_published,
+    event_failed_to_publish,
+    event_permanently_failed,
+    get_event_payload,
+)
 from jaiminho import settings
 
 logger = logging.getLogger(__name__)
@@ -101,6 +107,17 @@ def on_commit_hook(func, event, event_data, args, kwargs, using=None):
             f"JAIMINHO-ON-COMMIT-HOOK: Event sent successfully. Payload: {args}"
         )
     except BaseException as exc:
+        if is_non_retryable(exc):
+            if event:
+                event.delete()
+
+            logger.warning(
+                f"JAIMINHO-ON-COMMIT-HOOK: Non-retryable error, event will not be retried. Payload: {args}, "
+                f"Exception: {exc}"
+            )
+            event_permanently_failed.send(sender=func, event_payload=event_payload)
+            return
+
         if not event:
             event = Event.objects.using(using).create(**event_data)
 

--- a/jaiminho/publish_strategies.py
+++ b/jaiminho/publish_strategies.py
@@ -1,5 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
+from functools import partial
+
 import dill
 
 from django.db import transaction
@@ -64,7 +66,7 @@ class PublishOnCommitStrategy(BaseStrategy):
             "using": using,
         }
         transaction.on_commit(
-            lambda: on_commit_hook(**on_commit_hook_kwargs), using=using
+            partial(on_commit_hook, **on_commit_hook_kwargs), using=using
         )
         logger.info(
             f"JAIMINHO-SAVE-TO-OUTBOX: On commit hook configured. Event: {event}"

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -5,10 +5,12 @@ from django.core.signing import BadSignature
 from django.db import transaction
 
 from jaiminho.constants import PublishStrategyType
+from jaiminho.errors import is_non_retryable
 from jaiminho.models import Event
 from jaiminho.signals import (
     event_published_by_events_relay,
     event_failed_to_publish_by_events_relay,
+    event_permanently_failed_by_events_relay,
     get_event_payload,
 )
 from jaiminho import settings
@@ -93,6 +95,9 @@ class EventRelayer:
                     )
                     _capture_exception(exception)
 
+                    if self.__give_up_on_non_retryable(event, exception, event_payload):
+                        continue
+
                     if self.__stuck_on_error(event):
                         self.__warn_stuck_on_error(event)
                         return
@@ -103,6 +108,9 @@ class EventRelayer:
                     )
                     _capture_exception(e)
 
+                    if self.__give_up_on_non_retryable(event, e, event_payload):
+                        continue
+
                     if self.__stuck_on_error(event):
                         self.__warn_stuck_on_error(event)
                         return
@@ -111,17 +119,41 @@ class EventRelayer:
                     logger.warning(
                         f"JAIMINHO-EVENTS-RELAY: An error occurred when relaying event: {event} | Error: {str(e)}"
                     )
+                    _capture_exception(e)
+
+                    if self.__give_up_on_non_retryable(event, e, event_payload):
+                        continue
+
                     original_fn = _extract_original_func(event)
                     transaction.on_commit(
                         lambda: event_failed_to_publish_by_events_relay.send(
                             sender=original_fn, event_payload=event_payload
                         )
                     )
-                    _capture_exception(e)
 
                     if self.__stuck_on_error(event):
                         self.__warn_stuck_on_error(event)
                         return
+
+    def __give_up_on_non_retryable(self, event, exception, event_payload):
+        if not is_non_retryable(exception):
+            return False
+
+        try:
+            original_fn = _extract_original_func(event)
+        except BaseException:
+            original_fn = None
+
+        transaction.on_commit(
+            lambda: event_permanently_failed_by_events_relay.send(
+                sender=original_fn, event_payload=event_payload
+            )
+        )
+        logger.warning(
+            f"JAIMINHO-EVENTS-RELAY: Non-retryable error, event will not be retried. Event: {event}"
+        )
+        event.delete()
+        return True
 
     def __stuck_on_error(self, event):
         if not event.strategy:

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -145,6 +145,11 @@ class EventRelayer:
         if not is_non_retryable(exception):
             return False
 
+        if self.__stuck_on_error(event):
+            # Keep Order guarantees delivery order, so we can't skip a permanently
+            # failing event without risking later events being delivered out of order.
+            return False
+
         try:
             original_fn = _extract_original_func(event)
         except BaseException:

--- a/jaiminho/relayer.py
+++ b/jaiminho/relayer.py
@@ -1,4 +1,6 @@
 import logging
+from functools import partial
+
 import dill
 
 from django.core.signing import BadSignature
@@ -85,8 +87,10 @@ class EventRelayer:
                         )
 
                     transaction.on_commit(
-                        lambda: event_published_by_events_relay.send(
-                            sender=original_fn, event_payload=event_payload
+                        partial(
+                            event_published_by_events_relay.send,
+                            sender=original_fn,
+                            event_payload=event_payload,
                         )
                     )
                 except BadSignature as exception:
@@ -126,8 +130,10 @@ class EventRelayer:
 
                     original_fn = _extract_original_func(event)
                     transaction.on_commit(
-                        lambda: event_failed_to_publish_by_events_relay.send(
-                            sender=original_fn, event_payload=event_payload
+                        partial(
+                            event_failed_to_publish_by_events_relay.send,
+                            sender=original_fn,
+                            event_payload=event_payload,
                         )
                     )
 
@@ -145,8 +151,10 @@ class EventRelayer:
             original_fn = None
 
         transaction.on_commit(
-            lambda: event_permanently_failed_by_events_relay.send(
-                sender=original_fn, event_payload=event_payload
+            partial(
+                event_permanently_failed_by_events_relay.send,
+                sender=original_fn,
+                event_payload=event_payload,
             )
         )
         logger.warning(

--- a/jaiminho/settings.py
+++ b/jaiminho/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 
 from jaiminho.constants import PublishStrategyType
+from jaiminho.errors import DEFAULT_NON_RETRYABLE_EXCEPTIONS
 
 try:
     jaiminho_settings = getattr(settings, "JAIMINHO_CONFIG")
@@ -21,3 +22,6 @@ default_capture_exception = jaiminho_settings.get(
 )
 sign_events = jaiminho_settings.get("SIGN_EVENTS", True)
 verify_events_signature = jaiminho_settings.get("VERIFY_EVENTS_SIGNATURE", True)
+non_retryable_exceptions = tuple(
+    jaiminho_settings.get("NON_RETRYABLE_EXCEPTIONS", DEFAULT_NON_RETRYABLE_EXCEPTIONS)
+)

--- a/jaiminho/signals.py
+++ b/jaiminho/signals.py
@@ -2,8 +2,10 @@ from django import dispatch
 
 event_published = dispatch.Signal()
 event_failed_to_publish = dispatch.Signal()
+event_permanently_failed = dispatch.Signal()
 event_published_by_events_relay = dispatch.Signal()
 event_failed_to_publish_by_events_relay = dispatch.Signal()
+event_permanently_failed_by_events_relay = dispatch.Signal()
 
 
 def get_event_payload(args):

--- a/jaiminho/tests/test_errors.py
+++ b/jaiminho/tests/test_errors.py
@@ -1,0 +1,33 @@
+from django.core.signing import BadSignature
+
+from jaiminho.errors import is_non_retryable
+
+
+class TestIsNonRetryable:
+    def test_bad_signature_is_non_retryable(self):
+        assert is_non_retryable(BadSignature("tampered")) is True
+
+    def test_module_not_found_error_is_non_retryable(self):
+        assert is_non_retryable(ModuleNotFoundError()) is True
+
+    def test_attribute_error_is_non_retryable(self):
+        assert is_non_retryable(AttributeError()) is True
+
+    def test_other_exceptions_are_not_non_retryable(self):
+        assert is_non_retryable(ValueError()) is False
+
+    def test_configured_exception_is_non_retryable(self, mocker):
+        class MyCustomError(Exception):
+            pass
+
+        mocker.patch("jaiminho.settings.non_retryable_exceptions", (MyCustomError,))
+
+        assert is_non_retryable(MyCustomError()) is True
+
+    def test_configured_exceptions_replace_the_defaults(self, mocker):
+        class MyCustomError(Exception):
+            pass
+
+        mocker.patch("jaiminho.settings.non_retryable_exceptions", (MyCustomError,))
+
+        assert is_non_retryable(BadSignature("tampered")) is False

--- a/jaiminho_django_test_project/app/signals.py
+++ b/jaiminho_django_test_project/app/signals.py
@@ -18,6 +18,11 @@ def on_event_not_published(signal, sender, event_payload, **kwargs):
     log_metric("event-failed-to-publish", event_payload, **kwargs)
 
 
+@receiver(jaiminho.signals.event_permanently_failed)
+def on_event_permanently_failed(signal, sender, event_payload, **kwargs):
+    log_metric("event-permanently-failed", event_payload, **kwargs)
+
+
 @receiver(jaiminho.signals.event_published_by_events_relay)
 def on_event_published_through_relay_command(signal, sender, event_payload, **kwargs):
     log_metric("event-published-through-outbox", event_payload, **kwargs)
@@ -28,3 +33,10 @@ def on_event_not_published_through_relay_command(
     signal, sender, event_payload, **kwargs
 ):
     log_metric("event-failed-to-publish-through-outbox", event_payload, **kwargs)
+
+
+@receiver(jaiminho.signals.event_permanently_failed_by_events_relay)
+def on_event_permanently_failed_through_relay_command(
+    signal, sender, event_payload, **kwargs
+):
+    log_metric("event-permanently-failed-through-outbox", event_payload, **kwargs)

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -642,7 +642,9 @@ class TestValidateEventsRelay:
         mock_internal_notify_fail.assert_has_calls([call_1, call_2], any_order=True)
         assert "Events relaying are stuck due to failing Event" not in caplog.text
 
-    @pytest.mark.parametrize("publish_strategy", (PublishStrategyType.KEEP_ORDER,))
+    @pytest.mark.parametrize(
+        "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)
+    )
     def test_relay_not_stuck_when_one_fail_with_non_retryable_error(
         self,
         mock_internal_notify,
@@ -682,6 +684,41 @@ class TestValidateEventsRelay:
         assert "Events relaying are stuck due to failing Event" not in caplog.text
         assert Event.objects.filter(id=event_1.id).count() == 0
         mock_event_permanently_failed_signal.assert_called_once()
+
+    @pytest.mark.parametrize("publish_strategy", (PublishStrategyType.KEEP_ORDER,))
+    def test_relay_stuck_when_one_fail_with_non_retryable_error(
+        self,
+        mock_internal_notify,
+        publish_strategy,
+        mocker,
+        caplog,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+        mock_event_permanently_failed_signal = mocker.patch(
+            "jaiminho.relayer.event_permanently_failed_by_events_relay.send",
+            autospec=True,
+        )
+
+        args2 = ({"b": 2},)
+        event_1 = EventFactory(
+            function=dill.dumps(notify),
+            message=dill.dumps(({"b": 1},)),
+            strategy=publish_strategy,
+        )
+        Event.objects.filter(id=event_1.id).update(message=b"")
+        EventFactory(
+            function=dill.dumps(notify),
+            kwargs=dill.dumps({"encoder": DjangoJSONEncoder, "a": "2"}),
+            strategy=publish_strategy,
+            message=dill.dumps(args2),
+        )
+
+        call_command(validate_events_relay.Command())
+
+        mock_internal_notify.assert_not_called()
+        assert "Events relaying are stuck due to failing Event" in caplog.text
+        assert Event.objects.filter(id=event_1.id).count() == 1
+        mock_event_permanently_failed_signal.assert_not_called()
 
     @pytest.mark.parametrize("publish_strategy", (PublishStrategyType.KEEP_ORDER,))
     def test_relay_stuck_when_one_fail_and_specific_stream(
@@ -835,7 +872,11 @@ class TestValidateEventsRelay:
         assert "No module named 'jaiminho_django_test_project.send2'" == str(
             capture_exception_call
         )
-        assert Event.objects.count() == 0
+        if publish_strategy == PublishStrategyType.KEEP_ORDER:
+            assert Event.objects.count() == 1
+            assert "Events relaying are stuck due to failing Event" in caplog.text
+        else:
+            assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",
@@ -859,7 +900,11 @@ class TestValidateEventsRelay:
         assert "Event has been tampered" in caplog.text
         capture_exception_call = mock_capture_exception_fn.call_args[0][0]
         assert f"Event(id={event.id}) has been tampered" == str(capture_exception_call)
-        assert Event.objects.count() == 0
+        if publish_strategy == PublishStrategyType.KEEP_ORDER:
+            assert Event.objects.count() == 1
+            assert "Events relaying are stuck due to failing Event" in caplog.text
+        else:
+            assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",
@@ -879,7 +924,11 @@ class TestValidateEventsRelay:
 
         assert "Function does not exist anymore" in caplog.text
         assert "Can't get attribute 'never_existed' on" in caplog.text
-        assert Event.objects.count() == 0
+        if publish_strategy == PublishStrategyType.KEEP_ORDER:
+            assert Event.objects.count() == 1
+            assert "Events relaying are stuck due to failing Event" in caplog.text
+        else:
+            assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",

--- a/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
+++ b/jaiminho_django_test_project/tests/management/commands/test_validate_relay_events.py
@@ -643,6 +643,47 @@ class TestValidateEventsRelay:
         assert "Events relaying are stuck due to failing Event" not in caplog.text
 
     @pytest.mark.parametrize("publish_strategy", (PublishStrategyType.KEEP_ORDER,))
+    def test_relay_not_stuck_when_one_fail_with_non_retryable_error(
+        self,
+        mock_internal_notify,
+        publish_strategy,
+        mocker,
+        caplog,
+        django_capture_on_commit_callbacks,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+        mock_event_permanently_failed_signal = mocker.patch(
+            "jaiminho.relayer.event_permanently_failed_by_events_relay.send",
+            autospec=True,
+        )
+
+        args2 = ({"b": 2},)
+        event_1 = EventFactory(
+            function=dill.dumps(notify),
+            message=dill.dumps(({"b": 1},)),
+            strategy=publish_strategy,
+        )
+        Event.objects.filter(id=event_1.id).update(message=b"")
+        event_2 = EventFactory(
+            function=dill.dumps(notify),
+            kwargs=dill.dumps({"encoder": DjangoJSONEncoder, "a": "2"}),
+            strategy=publish_strategy,
+            message=dill.dumps(args2),
+        )
+
+        with django_capture_on_commit_callbacks(execute=True):
+            call_command(validate_events_relay.Command())
+
+        mock_internal_notify.assert_called_once_with(
+            args2[0],
+            encoder=DjangoJSONEncoder,
+            a="2",
+        )
+        assert "Events relaying are stuck due to failing Event" not in caplog.text
+        assert Event.objects.filter(id=event_1.id).count() == 0
+        mock_event_permanently_failed_signal.assert_called_once()
+
+    @pytest.mark.parametrize("publish_strategy", (PublishStrategyType.KEEP_ORDER,))
     def test_relay_stuck_when_one_fail_and_specific_stream(
         self,
         mock_internal_notify_fail,
@@ -794,6 +835,7 @@ class TestValidateEventsRelay:
         assert "No module named 'jaiminho_django_test_project.send2'" == str(
             capture_exception_call
         )
+        assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",
@@ -817,6 +859,7 @@ class TestValidateEventsRelay:
         assert "Event has been tampered" in caplog.text
         capture_exception_call = mock_capture_exception_fn.call_args[0][0]
         assert f"Event(id={event.id}) has been tampered" == str(capture_exception_call)
+        assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",
@@ -836,6 +879,7 @@ class TestValidateEventsRelay:
 
         assert "Function does not exist anymore" in caplog.text
         assert "Can't get attribute 'never_existed' on" in caplog.text
+        assert Event.objects.count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy",

--- a/jaiminho_django_test_project/tests/test_send.py
+++ b/jaiminho_django_test_project/tests/test_send.py
@@ -331,12 +331,9 @@ class TestNotify:
         "exception",
         (
             AssertionError,
-            ModuleNotFoundError,
-            AttributeError,
             Exception,
             SystemError,
             SystemExit,
-            BadSignature,
         ),
     )
     def test_send_fail_handles_multiple_exceptions_type(
@@ -362,6 +359,75 @@ class TestNotify:
             args[0],
         )
         assert len(callbacks) == 1
+        assert Event.objects.all().count() == 1
+
+    @pytest.mark.parametrize(
+        "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        (
+            ModuleNotFoundError,
+            AttributeError,
+            BadSignature,
+        ),
+    )
+    def test_send_fail_handles_non_retryable_exceptions_type(
+        self,
+        mock_log_metric,
+        mock_internal_notify_fail,
+        exception,
+        publish_strategy,
+        mocker,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+
+        mock_internal_notify_fail.side_effect = exception
+
+        args = ({"action": "a", "type": "t", "c": "d"},)
+        with TestCase.captureOnCommitCallbacks(execute=True) as callbacks:
+            jaiminho_django_test_project.send.notify(*args)
+
+        mock_internal_notify_fail.assert_called_once_with(*args)
+
+        mock_log_metric.assert_called_once_with(
+            "event-permanently-failed",
+            args[0],
+        )
+        assert len(callbacks) == 1
+        assert Event.objects.all().count() == 0
+
+    @pytest.mark.parametrize(
+        "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)
+    )
+    def test_send_fail_handles_app_configured_non_retryable_exception(
+        self,
+        mock_log_metric,
+        mock_internal_notify_fail,
+        publish_strategy,
+        mocker,
+    ):
+        class AppSpecificPermanentError(Exception):
+            pass
+
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+        mocker.patch(
+            "jaiminho.settings.non_retryable_exceptions", (AppSpecificPermanentError,)
+        )
+        mock_internal_notify_fail.side_effect = AppSpecificPermanentError
+
+        args = ({"action": "a", "type": "t", "c": "d"},)
+        with TestCase.captureOnCommitCallbacks(execute=True) as callbacks:
+            jaiminho_django_test_project.send.notify(*args)
+
+        mock_internal_notify_fail.assert_called_once_with(*args)
+
+        mock_log_metric.assert_called_once_with(
+            "event-permanently-failed",
+            args[0],
+        )
+        assert len(callbacks) == 1
+        assert Event.objects.all().count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)
@@ -743,7 +809,7 @@ class TestNotifyWithStream:
     )
     @pytest.mark.parametrize(
         "exception",
-        (AssertionError, AttributeError, Exception, SystemError, SystemExit),
+        (AssertionError, Exception, SystemError, SystemExit),
     )
     def test_send_to_stream_fail_handles_multiple_exceptions_type(
         self,
@@ -768,6 +834,39 @@ class TestNotifyWithStream:
             args[0],
         )
         assert len(callbacks) == 1
+        assert Event.objects.all().count() == 1
+
+    @pytest.mark.parametrize(
+        "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)
+    )
+    @pytest.mark.parametrize(
+        "exception",
+        (ModuleNotFoundError, AttributeError, BadSignature),
+    )
+    def test_send_to_stream_fail_handles_non_retryable_exceptions_type(
+        self,
+        mock_log_metric,
+        mock_internal_notify_fail,
+        exception,
+        publish_strategy,
+        mocker,
+    ):
+        mocker.patch("jaiminho.settings.publish_strategy", publish_strategy)
+
+        mock_internal_notify_fail.side_effect = exception
+
+        args = ({"action": "a", "type": "t", "c": "d"},)
+        with TestCase.captureOnCommitCallbacks(execute=True) as callbacks:
+            jaiminho_django_test_project.send.notify_to_stream(*args)
+
+        mock_internal_notify_fail.assert_called_once_with(*args)
+
+        mock_log_metric.assert_called_once_with(
+            "event-permanently-failed",
+            args[0],
+        )
+        assert len(callbacks) == 1
+        assert Event.objects.all().count() == 0
 
     @pytest.mark.parametrize(
         "publish_strategy", (PublishStrategyType.PUBLISH_ON_COMMIT,)


### PR DESCRIPTION
## Description
Non-retryable errors (tampered signature, missing function) are now dropped instead of retried forever. Adds a configurable `NON_RETRYABLE_EXCEPTIONS` setting, defaulting to `(BadSignature, ModuleNotFoundError, AttributeError)`.

## Motivation and Context
[CT-2898](https://loadsmart.atlassian.net/browse/CT-2898): django-jaiminho retried every failure forever, including permanent ones, which could poison the outbox and, under Keep Order, block every event queued behind the broken one. Mirrors the fix in [loadsmart/celery-sqs#47](https://github.com/loadsmart/celery-sqs/pull/47).

## How has this been tested?
Added/updated unit tests for `jaiminho/errors.py`, `on_commit_hook`, and `EventRelayer.relay` (including a Keep Order case proving the queue no longer gets stuck). Full suite green.

## What is the current behavior?
Every failure, including permanent ones, is retried forever via the outbox.

## What is the new behavior?
Events failing with a configured exception are dropped immediately instead of being persisted for retry.

[CT-2898]: https://loadsmart.atlassian.net/browse/CT-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for non-retryable exceptions.
  - Permanently failing events are now removed instead of being retried or persisted indefinitely, allowing subsequent events to continue processing.
  - Added signals for permanently failed events in direct publishing and relay workflows.

- **Documentation**
  - Documented the new configuration option and non-retryable failure behavior.
  - Updated the Celery integration example.

- **Bug Fixes**
  - Prevented malformed or permanently failing events from blocking ordered relay processing.
  - Preserved existing retry behavior for retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->